### PR TITLE
fix: now boost links are back

### DIFF
--- a/src/shortCodes/index.js
+++ b/src/shortCodes/index.js
@@ -26,7 +26,7 @@ async function updateTwitterEmbeds(twitterEmbeds, filepath) {
  */
 function boostLink(title, fileSlug, url, canonicalUrl) {
   const isVsCodeTips = url.startsWith('/vscodetips/');
-  if (!url.startsWith('/posts/') && !isVsCodeTips) {
+  if (!url.startsWith('/blog/') && !isVsCodeTips) {
     return '';
   }
 


### PR DESCRIPTION
## Description

Fixed an issue where boost links were no longer appearing. I missed a place when changing the URL from `/posts` to `/blog` which is why boost links weren't appearing anymore.

Relates to #68